### PR TITLE
Remove unnecessary find_package on roslaunch during build phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(gige_vision_framework_dalsa REQUIRED)
 find_package(OpenCV 3 REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  roslaunch
   cv_bridge
   sensor_msgs
   image_transport
@@ -40,7 +39,6 @@ target_link_libraries(camera_example
 install(TARGETS camera_example RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-
   find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(launch)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(camera_example
 install(TARGETS camera_example RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+
   find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(launch)
 


### PR DESCRIPTION
## Description
On the last PR I made some mistakes when change the base branch to autoproj (there were an extra find_package out of the test scope). Also, seems like `autoproj` ignores any tests defined in the package unless a directory called `test` exists.

## Overview
- Remove extra find_package on `roslaunch`;
- Add placeholder directory `test/`.

## Overrides
```yaml
- def_cam_teledyne_nano:
  branch: fix/missing-changes-last-pr
```